### PR TITLE
Filter Expression from Settings

### DIFF
--- a/linking_relation_editor/gui/linking_child_manager_dialog.py
+++ b/linking_relation_editor/gui/linking_child_manager_dialog.py
@@ -23,6 +23,7 @@ from qgis.gui import (
     QgsHighlight,
     QgsIdentifyMenu,
     QgsMessageBar,
+    QgsAttributeForm
 )
 from qgis.PyQt.QtCore import QModelIndex, Qt, QTimer
 from qgis.PyQt.QtWidgets import QAction, QDialog, QMessageBox
@@ -52,6 +53,7 @@ class LinkingChildManagerDialog(QDialog, WidgetUi):
         nmRelation: QgsRelation,
         editorContext: QgsAttributeEditorContext,
         oneToOne: bool,
+        filterExpression: str,
         linkingChildManagerDialogConfig: dict,
         parent=None,
     ):
@@ -64,6 +66,7 @@ class LinkingChildManagerDialog(QDialog, WidgetUi):
         self._nmRelation = nmRelation
         self._editorContext = editorContext
         self._oneToOne = oneToOne
+        self._filterExpression = filterExpression
         self._linkingChildManagerDialogConfig = linkingChildManagerDialogConfig
 
         self._mapToolSelect = None
@@ -185,7 +188,10 @@ class LinkingChildManagerDialog(QDialog, WidgetUi):
                 iface.messageBar(),
                 QgsMessageBar.defaultMessageTimeout(),
             )
-            self._feature_filter_widget.filterShowAll()
+            if self._filterExpression:
+                self._feature_filter_widget.setFilterExpression(self._filterExpression,QgsAttributeForm.ReplaceFilter, True)
+            else:
+                self._feature_filter_widget.filterShowAll()
 
         # Signal slots
         self.accepted.connect(self._accepting)

--- a/linking_relation_editor/gui/linking_child_manager_dialog.py
+++ b/linking_relation_editor/gui/linking_child_manager_dialog.py
@@ -29,6 +29,7 @@ from qgis.PyQt.QtCore import QModelIndex, Qt, QTimer
 from qgis.PyQt.QtWidgets import QAction, QDialog, QMessageBox
 from qgis.PyQt.uic import loadUiType
 from qgis.utils import iface
+from unittest.mock import MagicMock
 
 from linking_relation_editor.core.model.attribute_form_delegate import (
     AttributeFormDelegate,
@@ -180,18 +181,23 @@ class LinkingChildManagerDialog(QDialog, WidgetUi):
 
         self._feature_filter_widget = FeatureFilterWidget(self)
         self.mFooterHBoxLayout.insertWidget(0, self._feature_filter_widget)
-        if iface:  # TODO how to use iface in tests?
-            self._feature_filter_widget.init(
-                self._layer,
-                self._editorContext,
-                self._featuresModelFilterLeft,
-                iface.messageBar(),
-                QgsMessageBar.defaultMessageTimeout(),
-            )
-            if self._filterExpression:
-                self._feature_filter_widget.setFilterExpression(self._filterExpression,QgsAttributeForm.ReplaceFilter, True)
-            else:
-                self._feature_filter_widget.filterShowAll()
+        
+        # used for untittest
+        if not iface:
+            i = MagicMock()
+        else:
+            i = iface
+        self._feature_filter_widget.init(
+            self._layer,
+            self._editorContext,
+            self._featuresModelFilterLeft,
+            i.messageBar(),
+            QgsMessageBar.defaultMessageTimeout(),
+        )
+        if self._filterExpression:
+            self._feature_filter_widget.setFilterExpression(self._filterExpression,QgsAttributeForm.ReplaceFilter, True)
+        else:
+            self._feature_filter_widget.filterShowAll()
 
         # Signal slots
         self.accepted.connect(self._accepting)

--- a/linking_relation_editor/gui/linking_relation_editor_widget.py
+++ b/linking_relation_editor/gui/linking_relation_editor_widget.py
@@ -185,6 +185,7 @@ class LinkingRelationEditorWidget(QgsAbstractRelationEditorWidget, WidgetUi):
         return {
             "buttons": metaEnumFromValue(QgsRelationEditorWidget.Button.AllButtons).valueToKeys(self.visibleButtons()),
             "show_first_feature": self.mShowFirstFeature,
+            "filter_exression": self.mFilterExpression,
             CONFIG_ONE_TO_ONE: self.mOneToOne,
             CONFIG_LINKING_CHILD_MANAGER_DIALOG: self.mLinkingChildManagerDialogConfig,
         }
@@ -195,6 +196,7 @@ class LinkingRelationEditorWidget(QgsAbstractRelationEditorWidget, WidgetUi):
             config.get("buttons", metaEnumButtons.valueToKeys(QgsRelationEditorWidget.Button.AllButtons))
         )
         self.mShowFirstFeature = config.get("show_first_feature", True)
+        self.mFilterExpression = config.get("filter_expression")
         self.mOneToOne = config.get(CONFIG_ONE_TO_ONE)
         self.mLinkingChildManagerDialogConfig = config.get(CONFIG_LINKING_CHILD_MANAGER_DIALOG, {})
         self.updateButtons()
@@ -589,6 +591,7 @@ class LinkingRelationEditorWidget(QgsAbstractRelationEditorWidget, WidgetUi):
             self.nmRelation(),
             self.editorContext(),
             self.mOneToOne,
+            self.mFilterExpression,
             self.mLinkingChildManagerDialogConfig,
             self,
         )

--- a/linking_relation_editor/images/LinkingRelationEditor-icon.svg
+++ b/linking_relation_editor/images/LinkingRelationEditor-icon.svg
@@ -1,25 +1,165 @@
-<svg xmlns="http://www.w3.org/2000/svg" x="0%" y="0%" viewBox="0 0 24 24" xml:space="preserve">
-  <defs>
-    <linearGradient id="a" x1="-1.137%" y1="52.788%" x2="100%" y2="50%">
-      <stop offset="0%" style="stop-color:#73a44d;stop-opacity:1"/>
-      <stop offset="100%" style="stop-color:#1b4761;stop-opacity:1"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   x="0%"
+   y="0%"
+   viewBox="0 0 15.61 15.55"
+   xml:space="preserve"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="LinkingRelationEditor-icon.svg"
+   width="15.61"
+   height="15.55"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+   id="namedview18"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   inkscape:zoom="50.125"
+   inkscape:cx="7.5810474"
+   inkscape:cy="7.6708229"
+   inkscape:window-width="3440"
+   inkscape:window-height="1403"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg18" />
+  <defs
+   id="defs2">
+    <linearGradient
+   id="a"
+   x1="4.2143915"
+   y1="12.552681"
+   x2="19.971507"
+   y2="12.118312"
+   gradientTransform="matrix(1.0019274,0,0,0.9980763,-4.4,-4.32)"
+   gradientUnits="userSpaceOnUse">
+      <stop
+   offset="0%"
+   style="stop-color:#73a44d;stop-opacity:1"
+   id="stop1" />
+      <stop
+   offset="100%"
+   style="stop-color:#1b4761;stop-opacity:1"
+   id="stop2" />
     </linearGradient>
   </defs>
-  <path fill="url(#a)" stroke="#FFF" stroke-width=".48" stroke-linecap="square" d="M12.2 4.56c4.18 0 7.57 3.37 7.57 7.54 0 4.16-3.39 7.53-7.57 7.53s-7.56-3.37-7.56-7.53c0-4.17 3.38-7.54 7.56-7.54z"/>
-  <path fill="none" stroke="#FDFDFD" stroke-width=".48" stroke-linecap="square" d="m12.3 4.61-.02 15"/>
-  <path fill="none" stroke="#FFF" stroke-width=".48" stroke-linecap="square" d="M4.64 12.18h15.01"/>
-  <path fill="none" stroke="#000" stroke-width=".24" stroke-linecap="square" d="M12.24 4.57c4.17 0 7.56 3.37 7.56 7.54 0 4.16-3.39 7.53-7.56 7.53-4.18 0-7.57-3.37-7.57-7.53 0-4.17 3.39-7.54 7.57-7.54z"/>
-  <path fill="#339400" stroke="#000" stroke-width=".24" stroke-linecap="round" d="M13.09 6.17h2.63m-2.63 1 3.36-.01"/>
-  <path fill="none" stroke="#030303" stroke-width=".24" stroke-linecap="square" d="m4.68 12.18 15.02-.01"/>
-  <path fill="#339400" stroke="#000" stroke-width=".24" stroke-linecap="round" d="m13.1 8.15 3.36-.02m-3.3 1.13 5.44.12"/>
-  <path fill="none" stroke="#000" stroke-width=".24" stroke-linecap="square" d="m12.3 4.61-.02 15"/>
-  <path fill="#339400" stroke="#000" stroke-width=".24" stroke-linecap="round" d="m13.24 11.31 5.89-.02m-6.19-.94 5.88-.01"/>
-  <path fill="#7F7F7F" stroke="#FFF" stroke-width=".768" stroke-linecap="square" d="m5.92 15.76 4.56-4.08a.73.73 0 0 1 1.03.05l1.31 1.47a.73.73 0 0 1-.06 1.02l-4.55 4.09a.73.73 0 0 1-1.03-.06l-1.32-1.46a.73.73 0 0 1 .06-1.03z"/>
-  <path d="m12.148 10.205 4.55-4.08a.73.73 0 0 1 1.03.06l1.31 1.46a.73.73 0 0 1-.05 1.03l-4.56 4.08a.73.73 0 0 1-1.03-.05l-1.31-1.47a.73.73 0 0 1 .06-1.03z" style="fill:#bcbcbc;fill-opacity:1;fill-rule:nonzero;stroke:#fff;stroke-width:.76800001;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"/>
-  <path fill="none" stroke="#000" stroke-width=".384" stroke-linecap="square" d="m5.92 15.76 4.56-4.08a.73.73 0 0 1 1.03.05l1.31 1.47a.73.73 0 0 1-.06 1.02l-4.55 4.09a.73.73 0 0 1-1.03-.06l-1.32-1.46a.73.73 0 0 1 .06-1.03z"/>
-  <path d="m12.148 10.205 4.55-4.08a.73.73 0 0 1 1.03.06l1.31 1.46a.73.73 0 0 1-.05 1.03l-4.56 4.08a.73.73 0 0 1-1.03-.05l-1.31-1.47a.73.73 0 0 1 .06-1.03z" style="fill:#aeaeae;fill-opacity:0;fill-rule:nonzero;stroke:#000;stroke-width:.384;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" fill="none"/>
-  <path d="m11.292 13.224 2.32-2.1" style="fill:#000;fill-opacity:0;fill-rule:nonzero;stroke:#fff;stroke-width:.76800001;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" fill="none"/>
-  <path d="m11.292 13.224 2.32-2.1" style="fill:#000;fill-opacity:0;fill-rule:nonzero;stroke:#000;stroke-width:.384;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" fill="none"/>
-  <path fill="#73A44D" stroke="#000" stroke-width=".24" stroke-linecap="round" d="M10.35 6.29c.42 0 .76.35.76.77 0 .42-.34.77-.76.77a.76.76 0 0 1-.75-.77c0-.42.33-.77.75-.77zm-.8 2.84c.34 0 .62.28.62.63s-.28.63-.62.63c-.34 0-.62-.28-.62-.63s.28-.63.62-.63zm-2.39-.31c.28 0 .51.21.51.47s-.23.47-.51.47-.5-.21-.5-.47.22-.47.5-.47z"/>
-  <path fill="#1B4761" stroke="#000" stroke-width=".24" stroke-linecap="round" d="m13.72 14.41 1.91-.96 1.85.92v1.2l-.77.76-1.22-.16-.08 1.41-1.7-.47-.4-.47-.34-.7.84-.37-.09-1.16z"/>
+  <path
+   fill="url(#a)"
+   stroke="#ffffff"
+   stroke-width="0.48"
+   stroke-linecap="square"
+   d="m 7.8,0.23999999 c 4.18,0 7.57,3.37000001 7.57,7.54000001 0,4.16 -3.39,7.53 -7.57,7.53 C 3.62,15.31 0.23999999,11.94 0.23999999,7.78 0.23999999,3.61 3.62,0.23999999 7.8,0.23999999 Z"
+   id="path2"
+   style="fill:url(#a)" />
+  <path
+   fill="none"
+   stroke="#fdfdfd"
+   stroke-width="0.48"
+   stroke-linecap="square"
+   d="M 7.9,0.28999999 7.88,15.29"
+   id="path3" />
+  <path
+   fill="none"
+   stroke="#ffffff"
+   stroke-width="0.48"
+   stroke-linecap="square"
+   d="M 0.23999999,7.86 H 15.25"
+   id="path4" />
+  <path
+   fill="none"
+   stroke="#000000"
+   stroke-width="0.24"
+   stroke-linecap="square"
+   d="m 7.84,0.24999999 c 4.17,0 7.56,3.37000001 7.56,7.54000001 0,4.16 -3.39,7.53 -7.56,7.53 C 3.66,15.32 0.26999999,11.95 0.26999999,7.79 0.26999999,3.62 3.66,0.24999999 7.84,0.24999999 Z"
+   id="path5" />
+  <path
+   fill="#339400"
+   stroke="#000000"
+   stroke-width="0.24"
+   stroke-linecap="round"
+   d="m 8.69,1.85 h 2.63 m -2.63,1 3.36,-0.01"
+   id="path6" />
+  <path
+   fill="none"
+   stroke="#030303"
+   stroke-width="0.24"
+   stroke-linecap="square"
+   d="M 0.27999999,7.86 15.3,7.85"
+   id="path7" />
+  <path
+   fill="#339400"
+   stroke="#000000"
+   stroke-width="0.24"
+   stroke-linecap="round"
+   d="M 8.7,3.83 12.06,3.81 M 8.76,4.94 14.2,5.06"
+   id="path8" />
+  <path
+   fill="none"
+   stroke="#000000"
+   stroke-width="0.24"
+   stroke-linecap="square"
+   d="M 7.9,0.28999999 7.88,15.29"
+   id="path9" />
+  <path
+   fill="#339400"
+   stroke="#000000"
+   stroke-width="0.24"
+   stroke-linecap="round"
+   d="M 8.84,6.99 14.73,6.97 M 8.54,6.03 14.42,6.02"
+   id="path10" />
+  <path
+   fill="#7f7f7f"
+   stroke="#ffffff"
+   stroke-width="0.768"
+   stroke-linecap="square"
+   d="M 1.52,11.44 6.08,7.36 A 0.73,0.73 0 0 1 7.11,7.41 L 8.42,8.88 A 0.73,0.73 0 0 1 8.36,9.9 L 3.81,13.99 A 0.73,0.73 0 0 1 2.78,13.93 L 1.46,12.47 a 0.73,0.73 0 0 1 0.06,-1.03 z"
+   id="path11" />
+  <path
+   d="m 7.748,5.885 4.55,-4.08 a 0.73,0.73 0 0 1 1.03,0.06 l 1.31,1.46 a 0.73,0.73 0 0 1 -0.05,1.03 l -4.56,4.08 a 0.73,0.73 0 0 1 -1.03,-0.05 l -1.31,-1.47 a 0.73,0.73 0 0 1 0.06,-1.03 z"
+   style="fill:#bcbcbc;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.768;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
+   id="path12" />
+  <path
+   fill="none"
+   stroke="#000000"
+   stroke-width="0.384"
+   stroke-linecap="square"
+   d="M 1.52,11.44 6.08,7.36 A 0.73,0.73 0 0 1 7.11,7.41 L 8.42,8.88 A 0.73,0.73 0 0 1 8.36,9.9 L 3.81,13.99 A 0.73,0.73 0 0 1 2.78,13.93 L 1.46,12.47 a 0.73,0.73 0 0 1 0.06,-1.03 z"
+   id="path13" />
+  <path
+   d="m 7.748,5.885 4.55,-4.08 a 0.73,0.73 0 0 1 1.03,0.06 l 1.31,1.46 a 0.73,0.73 0 0 1 -0.05,1.03 l -4.56,4.08 a 0.73,0.73 0 0 1 -1.03,-0.05 l -1.31,-1.47 a 0.73,0.73 0 0 1 0.06,-1.03 z"
+   style="fill:#aeaeae;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:0.384;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
+   fill="none"
+   id="path14" />
+  <path
+   d="m 6.892,8.904 2.32,-2.1"
+   style="fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.768;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+   fill="none"
+   id="path15" />
+  <path
+   d="m 6.892,8.904 2.32,-2.1"
+   style="fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#000000;stroke-width:0.384;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+   fill="none"
+   id="path16" />
+  <path
+   fill="#73a44d"
+   stroke="#000000"
+   stroke-width="0.24"
+   stroke-linecap="round"
+   d="m 5.95,1.97 c 0.42,0 0.76,0.35 0.76,0.77 0,0.42 -0.34,0.77 -0.76,0.77 A 0.76,0.76 0 0 1 5.2,2.74 C 5.2,2.32 5.53,1.97 5.95,1.97 Z m -0.8,2.84 c 0.34,0 0.62,0.28 0.62,0.63 0,0.35 -0.28,0.63 -0.62,0.63 C 4.81,6.07 4.53,5.79 4.53,5.44 4.53,5.09 4.81,4.81 5.15,4.81 Z M 2.76,4.5 c 0.28,0 0.51,0.21 0.51,0.47 0,0.26 -0.23,0.47 -0.51,0.47 -0.28,0 -0.5,-0.21 -0.5,-0.47 0,-0.26 0.22,-0.47 0.5,-0.47 z"
+   id="path17" />
+  <path
+   fill="#1b4761"
+   stroke="#000000"
+   stroke-width="0.24"
+   stroke-linecap="round"
+   d="m 9.32,10.09 1.91,-0.96 1.85,0.92 v 1.2 l -0.77,0.76 -1.22,-0.16 -0.08,1.41 -1.7,-0.47 -0.4,-0.47 -0.34,-0.7 0.84,-0.37 z"
+   id="path18" />
 </svg>

--- a/linking_relation_editor/tests/test_linking_child_manager_dialog.py
+++ b/linking_relation_editor/tests/test_linking_child_manager_dialog.py
@@ -138,6 +138,7 @@ class TestLinkingChildManagerDialog(unittest.TestCase):
             QgsRelation(),
             QgsAttributeEditorContext(),
             False,
+            None,
             {},
             None,
         )
@@ -160,6 +161,7 @@ class TestLinkingChildManagerDialog(unittest.TestCase):
             QgsRelation(),
             QgsAttributeEditorContext(),
             False,
+            None,
             {},
             None,
         )
@@ -182,6 +184,7 @@ class TestLinkingChildManagerDialog(unittest.TestCase):
             self.mRelationNM,
             QgsAttributeEditorContext(),
             False,
+            None,
             {},
             None,
         )
@@ -206,6 +209,7 @@ class TestLinkingChildManagerDialog(unittest.TestCase):
             QgsRelation(),
             QgsAttributeEditorContext(),
             False,
+            None,
             {},
             None,
         )
@@ -295,6 +299,95 @@ class TestLinkingChildManagerDialog(unittest.TestCase):
         self.assertEqual(dialog._featuresModelFilterLeft.rowCount(), 0)
 
         dialog._featuresModelFilterLeft.set_quick_filter("")
+        # "Layer1-0: The Artist formerly known as Prince"
+        # "Layer1-1: Martina formerly known as Prisca"
+        self.assertEqual(dialog._featuresModelFilterLeft.rowCount(), 2)
+        self.assertEqual(
+            dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(0, 0), Qt.DisplayRole),
+            "Layer1-0: The Artist formerly known as Prince",
+        )
+        self.assertEqual(
+            dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(1, 0), Qt.DisplayRole),
+            "Layer1-1: Martina formerly known as Prisca",
+        )
+
+    def test_passed_filter_expression(self):
+        # get a parent with no childs
+        parentFeature = QgsFeature()
+        for feature in self.mLayer2.getFeatures():
+            if feature.attribute("pk") == 12:
+                parentFeature = feature
+                break
+
+        self.assertTrue(parentFeature.isValid())
+
+        dialog = LinkingChildManagerDialog(
+            self.mLayer1,
+            self.mLayer2,
+            parentFeature,
+            self.mRelation,
+            QgsRelation(),
+            QgsAttributeEditorContext(),
+            False,
+            None,
+            {},
+            None,
+        )
+
+        self.assertEqual(dialog.mLayerNameLabel.text(), self.mLayer1.name())
+
+        # all entries
+        # "Layer1-0: The Artist formerly known as Prince"
+        # "Layer1-1: Martina formerly known as Prisca"
+        self.assertEqual(dialog._featuresModelFilterLeft.rowCount(), 2)
+        self.assertEqual(
+            dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(0, 0), Qt.DisplayRole),
+            "Layer1-0: The Artist formerly known as Prince",
+        )
+        self.assertEqual(
+            dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(1, 0), Qt.DisplayRole),
+            "Layer1-1: Martina formerly known as Prisca",
+        )        
+        
+        dialog = LinkingChildManagerDialog(
+            self.mLayer1,
+            self.mLayer2,
+            parentFeature,
+            self.mRelation,
+            QgsRelation(),
+            QgsAttributeEditorContext(),
+            False,
+            "name LIKE '%formerly known as Prince%'",
+            {},
+            None,
+        )
+
+        self.assertEqual(dialog.mLayerNameLabel.text(), self.mLayer1.name())
+
+        # one entry
+        # "Layer1-0: The Artist formerly known as Prince"
+        self.assertEqual(dialog._featuresModelFilterLeft.rowCount(), 1)
+        self.assertEqual(
+            dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(0, 0), Qt.DisplayRole),
+            "Layer1-0: The Artist formerly known as Prince",
+        )
+        
+        dialog = LinkingChildManagerDialog(
+            self.mLayer1,
+            self.mLayer2,
+            parentFeature,
+            self.mRelation,
+            QgsRelation(),
+            QgsAttributeEditorContext(),
+            False,
+            "name LIKE '%formerly%'",
+            {},
+            None,
+        )
+
+        self.assertEqual(dialog.mLayerNameLabel.text(), self.mLayer1.name())
+
+        # all entries with formerly
         # "Layer1-0: The Artist formerly known as Prince"
         # "Layer1-1: Martina formerly known as Prisca"
         self.assertEqual(dialog._featuresModelFilterLeft.rowCount(), 2)

--- a/linking_relation_editor/tests/test_linking_child_manager_dialog.py
+++ b/linking_relation_editor/tests/test_linking_child_manager_dialog.py
@@ -320,34 +320,6 @@ class TestLinkingChildManagerDialog(unittest.TestCase):
                 break
 
         self.assertTrue(parentFeature.isValid())
-
-        dialog = LinkingChildManagerDialog(
-            self.mLayer1,
-            self.mLayer2,
-            parentFeature,
-            self.mRelation,
-            QgsRelation(),
-            QgsAttributeEditorContext(),
-            False,
-            None,
-            {},
-            None,
-        )
-
-        self.assertEqual(dialog.mLayerNameLabel.text(), self.mLayer1.name())
-
-        # all entries
-        # "Layer1-0: The Artist formerly known as Prince"
-        # "Layer1-1: Martina formerly known as Prisca"
-        self.assertEqual(dialog._featuresModelFilterLeft.rowCount(), 2)
-        self.assertEqual(
-            dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(0, 0), Qt.DisplayRole),
-            "Layer1-0: The Artist formerly known as Prince",
-        )
-        self.assertEqual(
-            dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(1, 0), Qt.DisplayRole),
-            "Layer1-1: Martina formerly known as Prisca",
-        )        
         
         dialog = LinkingChildManagerDialog(
             self.mLayer1,
@@ -399,3 +371,27 @@ class TestLinkingChildManagerDialog(unittest.TestCase):
             dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(1, 0), Qt.DisplayRole),
             "Layer1-1: Martina formerly known as Prisca",
         )
+        
+        dialog = LinkingChildManagerDialog(
+            self.mLayer1,
+            self.mLayer2,
+            parentFeature,
+            self.mRelation,
+            QgsRelation(),
+            QgsAttributeEditorContext(),
+            False,
+            "name LIKE '%Prisca%'",
+            {},
+            None,
+        )
+
+        self.assertEqual(dialog.mLayerNameLabel.text(), self.mLayer1.name())
+
+        # one entry
+        # "Layer1-0: The Artist formerly known as Prince"
+        self.assertEqual(dialog._featuresModelFilterLeft.rowCount(), 1)
+        self.assertEqual(
+            dialog._featuresModelFilterLeft.data(dialog._featuresModelFilterLeft.index(0, 0), Qt.DisplayRole),
+            "Layer1-1: Martina formerly known as Prisca",
+        )
+    


### PR DESCRIPTION
Kind of "default" filter expression from the settings.

[Screencast from 21.08.2024 10:54:12.webm](https://github.com/user-attachments/assets/62922664-9bb9-40b2-86da-99005c3f72c5)

According to https://github.com/qgis/QGIS/pull/58448

It does not need a QGIS version check. It's just empty when not available because QGIS version < 3.40 :shrug:
