### PR TITLE
Print a warning when the relations are invalid

### DIFF
--- a/linking_relation_editor/gui/linking_relation_editor_widget.py
+++ b/linking_relation_editor/gui/linking_relation_editor_widget.py
@@ -774,15 +774,18 @@ class LinkingRelationEditorWidget(QgsAbstractRelationEditorWidget, WidgetUi):
     def afterSetRelations(self):
         self._nmRelation = QgsProject.instance().relationManager().relation(str(self.nmRelationId()))
 
-        self._checkTransactionGroup()
-
         if self.relation().isValid():
+            self._checkTransactionGroup()
+
             self.relation().referencingLayer().editingStopped.connect(self.updateButtons)
             self.relation().referencingLayer().editingStarted.connect(self.updateButtons)
 
         if self.nmRelation().isValid():
             self.nmRelation().referencedLayer().editingStarted.connect(self.updateButtons)
             self.nmRelation().referencedLayer().editingStopped.connect(self.updateButtons)
+
+        if not self.relation().isValid() and not self.nmRelation().isValid():
+            QgsLogger.warning(self.tr(f"No valid relation set. Relation id: '{self.relation().id()}' NM relation id: '{self.nmRelationId()}'"))
 
         self.updateButtons()
 

--- a/linking_relation_editor/gui/linking_relation_editor_widget.py
+++ b/linking_relation_editor/gui/linking_relation_editor_widget.py
@@ -774,18 +774,19 @@ class LinkingRelationEditorWidget(QgsAbstractRelationEditorWidget, WidgetUi):
     def afterSetRelations(self):
         self._nmRelation = QgsProject.instance().relationManager().relation(str(self.nmRelationId()))
 
-        if self.relation().isValid():
-            self._checkTransactionGroup()
+        if not self.relation().isValid():
+            QgsLogger.warning(self.tr(f"Invalid relation set, relation id: '{self.relation().id()}'"))
+            self.updateButtons()
+            return
 
-            self.relation().referencingLayer().editingStopped.connect(self.updateButtons)
-            self.relation().referencingLayer().editingStarted.connect(self.updateButtons)
+        self._checkTransactionGroup()
+
+        self.relation().referencingLayer().editingStopped.connect(self.updateButtons)
+        self.relation().referencingLayer().editingStarted.connect(self.updateButtons)
 
         if self.nmRelation().isValid():
             self.nmRelation().referencedLayer().editingStarted.connect(self.updateButtons)
             self.nmRelation().referencedLayer().editingStopped.connect(self.updateButtons)
-
-        if not self.relation().isValid() and not self.nmRelation().isValid():
-            QgsLogger.warning(self.tr(f"No valid relation set. Relation id: '{self.relation().id()}' NM relation id: '{self.nmRelationId()}'"))
 
         self.updateButtons()
 


### PR DESCRIPTION
This can happen if a relation is deleted after the widget was added to a layer configuration.

With this changes the issue persists but it logs a warning instead of throwing a python exception when trying to access referencedLayer()